### PR TITLE
Unify SafeMath logic between add and sub

### DIFF
--- a/contracts/MetaKeep3r.sol
+++ b/contracts/MetaKeep3r.sol
@@ -3,10 +3,7 @@ pragma solidity ^0.5.17;
 
 library SafeMath {
     function add(uint a, uint b) internal pure returns (uint) {
-        uint c = a + b;
-        require(c >= a, "add: +");
-
-        return c;
+        return add(a, b, "add: +")
     }
     function add(uint a, uint b, string memory errorMessage) internal pure returns (uint) {
         uint c = a + b;


### PR DESCRIPTION
- Small cleanup that doesn't change the behavior, but should make it easier to reason about this section of the code and help with audits.
- Removes some duplicated `add` logic.
- Now `add(a, b)` and `sub(a, b)` use the same approach to delegate to the overloaded function.