### PR TITLE
Use Memory Type Variable Instead of Storage Type Variable in Event to Save Gas

### DIFF
--- a/contracts/jobs/HegicPoolKeep3r.sol
+++ b/contracts/jobs/HegicPoolKeep3r.sol
@@ -41,7 +41,7 @@ contract HegicPoolKeep3r is Governable, CollectableDust, Keep3r, IHegicPoolKeep3
   function setMinRewards(uint256 _minETHRewards, uint256 _minWBTCRewards) public override onlyGovernor {
     minETHRewards = _minETHRewards;
     minWBTCRewards = _minWBTCRewards;
-    emit MinRewardsSet(minETHRewards, minWBTCRewards);
+    emit MinRewardsSet(_minETHRewards, _minWBTCRewards);
   }
 
   function setKeep3r(address _keep3r) public override onlyGovernor {


### PR DESCRIPTION
Hi, we are a research group on programming languages and software engineering. We recently have conducted a systematic study about Solidity event usage, evolution, and impact, and we are attempting to build a tool to improve the practice of Solidity event use based on our findings. We have tried our prototype tool on some of the most popular GitHub Solidity repositories, and for your repository, we find a potential optimization of gas consumption arisen from event use.  

The point is that when we use emit operation to store the value of a certain variable, `local memory type variable` would be preferable to `storage type (state) variable` if they hold the same value. The reason is that an extra SLOAD operation would be needed to access the variable if it is storage type, and the SLOAD operation costs 800 gas.

For your repository, we find that several event uses can be improved.